### PR TITLE
add isDirectory to VirtualFileReference and subclasses

### DIFF
--- a/src/main/java/com/addthis/meshy/LocalFileHandlerMux.java
+++ b/src/main/java/com/addthis/meshy/LocalFileHandlerMux.java
@@ -118,6 +118,10 @@ public class LocalFileHandlerMux implements LocalFileHandler {
             return null;
         }
 
+        @Override public boolean isDirectory() {
+            return false;
+        }
+
         @Override
         public VirtualFileInput getInput(Map<String, String> options) {
             try {

--- a/src/main/java/com/addthis/meshy/LocalFileSystem.java
+++ b/src/main/java/com/addthis/meshy/LocalFileSystem.java
@@ -119,6 +119,11 @@ public class LocalFileSystem implements VirtualFileSystem {
             return ptr.length();
         }
 
+        @Override
+        public boolean isDirectory() {
+            return ptr.isDirectory();
+        }
+
         @Nullable @Override
         public Iterator<VirtualFileReference> listFiles(@Nonnull final PathMatcher filter) {
             try {

--- a/src/main/java/com/addthis/meshy/VirtualFileReference.java
+++ b/src/main/java/com/addthis/meshy/VirtualFileReference.java
@@ -29,6 +29,8 @@ public interface VirtualFileReference {
 
     public long getLength();
 
+    public boolean isDirectory();
+
     public Iterator<VirtualFileReference> listFiles(@Nonnull PathMatcher filter);
 
     public VirtualFileReference getFile(String name);

--- a/src/main/java/com/addthis/meshy/service/file/FileTarget.java
+++ b/src/main/java/com/addthis/meshy/service/file/FileTarget.java
@@ -257,7 +257,7 @@ public class FileTarget extends TargetHandler implements Runnable {
             localFindTimer.update(localRunTime, TimeUnit.MILLISECONDS);
         } finally {
             if (forwardMetaData) {
-                FileReference flagRef = new FileReference("localfind", 0, 0);
+                FileReference flagRef = new FileReference("localfind", 0, 0, false);
                 FileTarget.this.send(flagRef.encode(null));
             }
             //Expected conditions under which we should cleanup: If we do not expect a response from the mesh
@@ -362,7 +362,7 @@ public class FileTarget extends TargetHandler implements Runnable {
 
     private void forwardPeerList(Collection<Channel> peerList) {
         int peerCount = peerList.size();
-        FileReference flagRef = new FileReference("peers", 0, peerCount);
+        FileReference flagRef = new FileReference("peers", 0, peerCount, false);
         send(flagRef.encode(FileTarget.peersToString(peerList)));
     }
 
@@ -550,7 +550,7 @@ public class FileTarget extends TargetHandler implements Runnable {
             super.receiveComplete(state, completedSession);
             if (forwardMetaData) {
                 int peerCount = getPeerCount();
-                FileReference flagRef = new FileReference("response", 0, peerCount);
+                FileReference flagRef = new FileReference("response", 0, peerCount, false);
                 FileTarget.this.send(flagRef.encode(state.getChannelRemoteAddress().getHostName()));
             }
             if (doComplete.compareAndSet(true, false) && !firstDone.compareAndSet(false, true)) {

--- a/src/main/java/com/addthis/meshy/service/message/MessageFile.java
+++ b/src/main/java/com/addthis/meshy/service/message/MessageFile.java
@@ -87,6 +87,10 @@ class MessageFile implements VirtualFileReference {
         return length;
     }
 
+    @Override public boolean isDirectory() {
+        return false;
+    }
+
     @Override
     public Iterator<VirtualFileReference> listFiles(PathMatcher filter) {
         synchronized (files) {

--- a/src/test/java/com/addthis/meshy/service/file/TestFileService.java
+++ b/src/test/java/com/addthis/meshy/service/file/TestFileService.java
@@ -36,32 +36,34 @@ public class TestFileService extends TestMesh {
         final MeshyServer server = getServer("src/test/files");
         final MeshyClient client = getClient(server);
         FileSource files = new FileSource(client, new String[]{
-                "*/*.xml",
-                "*/hosts",
+                "*/*",
+                "*/hosts"
         });
         files.waitComplete();
         log.info("file.list --> {}", files.getFileList());
         Map<String, FileReference> map = files.getFileMap();
-        checkFile(map, new FileReference("/a/abc.xml", 0, 4).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/a/def.xml", 0, 7).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/b/ghi.xml", 0, 4).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/b/jkl.xml", 0, 7).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/c/hosts", 0, 593366).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/mux/hosts", 0, 593366).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/abc.xml", 0, 4, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/def.xml", 0, 7, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/b/ghi.xml", 0, 4, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/b/jkl.xml", 0, 7, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/c/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/mux/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/d/dir", 0, 102, true).setHostUUID(server.getUUID()));
         /** second test exercises the cache */
         files = new FileSource(client, new String[]{
-                "*/*.xml",
+                "*/*",
                 "*/hosts",
         });
         files.waitComplete();
         log.info("file.list --> {}", files.getFileList());
         map = files.getFileMap();
-        checkFile(map, new FileReference("/a/abc.xml", 0, 4).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/a/def.xml", 0, 7).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/b/ghi.xml", 0, 4).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/b/jkl.xml", 0, 7).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/c/hosts", 0, 593366).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/mux/hosts", 0, 593366).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/abc.xml", 0, 4, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/def.xml", 0, 7, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/b/ghi.xml", 0, 4, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/b/jkl.xml", 0, 7, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/c/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/mux/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/d/dir", 0, 102, true).setHostUUID(server.getUUID()));
     }
 
     @Test
@@ -75,12 +77,12 @@ public class TestFileService extends TestMesh {
         files.waitComplete();
         log.info("file.list --> {}", files.getFileList());
         Map<String, FileReference> map = files.getFileMap();
-        checkFile(map, new FileReference("/a/abc.xml", 0, 4).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/a/def.xml", 0, 7).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/abc.xml", 0, 4, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/a/def.xml", 0, 7, false).setHostUUID(server.getUUID()));
         assertFalse(map.containsKey("/b/ghi.xml"));
         assertFalse(map.containsKey("/b/jkl.xml"));
-        checkFile(map, new FileReference("/c/hosts", 0, 593366).setHostUUID(server.getUUID()));
-        checkFile(map, new FileReference("/mux/hosts", 0, 593366).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/c/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/mux/hosts", 0, 593366, false).setHostUUID(server.getUUID()));
     }
 
     @Test
@@ -98,26 +100,26 @@ public class TestFileService extends TestMesh {
         log.info("file.list --> {}", files.getFileList());
         Map<String, FileReference> map = files.getFileMap();
         log.info("file map --> {}", map);
-        checkFile(map, new FileReference("/abc.xml", 0, 4).setHostUUID(server1.getUUID()));
-        checkFile(map, new FileReference("/def.xml", 0, 7).setHostUUID(server1.getUUID()));
-        checkFile(map, new FileReference("/ghi.xml", 0, 4).setHostUUID(server2.getUUID()));
-        checkFile(map, new FileReference("/jkl.xml", 0, 7).setHostUUID(server2.getUUID()));
-        checkFile(map, new FileReference("/xyz.xml", 0, 10).setHostUUID(server3.getUUID()));
+        checkFile(map, new FileReference("/abc.xml", 0, 4, false).setHostUUID(server1.getUUID()));
+        checkFile(map, new FileReference("/def.xml", 0, 7, false).setHostUUID(server1.getUUID()));
+        checkFile(map, new FileReference("/ghi.xml", 0, 4, false).setHostUUID(server2.getUUID()));
+        checkFile(map, new FileReference("/jkl.xml", 0, 7, false).setHostUUID(server2.getUUID()));
+        checkFile(map, new FileReference("/xyz.xml", 0, 10, false).setHostUUID(server3.getUUID()));
     }
 
     @Test
     public void testEquals() throws Exception {
         FileReference[] refs = new FileReference[5];
 
-        refs[0] = new FileReference("/a/abc.xml", 0, 4);
-        refs[1] = new FileReference("/a/def.xml", 0, 7);
-        refs[2] = new FileReference(null, 0, 4);
+        refs[0] = new FileReference("/a/abc.xml", 0, 4, false);
+        refs[1] = new FileReference("/a/def.xml", 0, 7, false);
+        refs[2] = new FileReference(null, 0, 4, false);
 
         // refs[0] and refs[3] are equal
-        refs[3] = new FileReference("/a/abc.xml", 0, 4);
+        refs[3] = new FileReference("/a/abc.xml", 0, 4, false);
 
         // refs[2] and refs[4] are equal
-        refs[4] = new FileReference(null, 0, 4);
+        refs[4] = new FileReference(null, 0, 4, false);
 
         refs[0].setHostUUID("a");
         refs[1].setHostUUID("b");
@@ -151,10 +153,10 @@ public class TestFileService extends TestMesh {
     public void testHashCode() throws Exception {
         FileReference[] refs = new FileReference[4];
 
-        refs[0] = new FileReference("/a/abc.xml", 0, 4);
-        refs[1] = new FileReference("/a/abc.xml", 0, 4);
-        refs[2] = new FileReference(null, 0, 4);
-        refs[3] = new FileReference(null, 0, 4);
+        refs[0] = new FileReference("/a/abc.xml", 0, 4, false);
+        refs[1] = new FileReference("/a/abc.xml", 0, 4, false);
+        refs[2] = new FileReference(null, 0, 4, false);
+        refs[3] = new FileReference(null, 0, 4, false);
 
         refs[0].setHostUUID("a");
         refs[1].setHostUUID("a");

--- a/src/test/java/com/addthis/meshy/service/file/TestVFS.java
+++ b/src/test/java/com/addthis/meshy/service/file/TestVFS.java
@@ -59,7 +59,7 @@ public class TestVFS extends TestMesh {
         files.waitComplete();
         Map<String, FileReference> map = files.getFileMap();
         log.info("map={}", map);
-        checkFile(map, new FileReference("/dummy", 0, 0).setHostUUID(server.getUUID()));
+        checkFile(map, new FileReference("/dummy", 0, 0, false).setHostUUID(server.getUUID()));
     }
 
     public static class DummyHandler implements LocalFileHandler {
@@ -102,6 +102,10 @@ public class TestVFS extends TestMesh {
         @Override
         public long getLength() {
             return 0;
+        }
+
+        @Override public boolean isDirectory() {
+            return false;
         }
 
         @Override


### PR DESCRIPTION
Only FileReference actually implements it, other implementations always return false

Purpose: to allow my hackathon project, a browser-based mesh browser, to know if it should list or download a file.